### PR TITLE
Allows web clients to subscribe to an event before the video starts

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -27,9 +27,12 @@ type Handler struct {
 }
 
 func (h *Handler) AddNewClient(streamID string, audioTrack, videoTrack *webrtc.Track) error {
-	pubsub, err := h.relayService.GetPubsub(streamID)
+
+	var pubsub *Pubsub
+	var err error
+	pubsub, err = h.relayService.GetPubsub(streamID)
 	if err != nil {
-		return errors.Wrap(err, "Failed to get pubsub")
+		pubsub, err = h.relayService.NewPubsub(streamID)
 	}
 
 	sub := pubsub.Sub(audioTrack, videoTrack)
@@ -63,9 +66,17 @@ func (h *Handler) OnPublish(_ *rtmp.StreamContext, timestamp uint32, cmd *rtmpms
 		return errors.New("PublishingName is empty")
 	}
 
-	pubsub, err := h.relayService.NewPubsub(cmd.PublishingName)
+	log.Println(cmd.PublishingName)
+
+	var pubsub *Pubsub
+	var err error
+	pubsub, err = h.relayService.GetPubsub(cmd.PublishingName)
+
 	if err != nil {
-		return errors.Wrap(err, "Failed to create pubsub")
+		pubsub, err = h.relayService.NewPubsub(cmd.PublishingName)
+		if err != nil {
+			return errors.Wrap(err, "Failed to create pubsub")
+		}
 	}
 
 	pub := pubsub.Pub()
@@ -104,7 +115,7 @@ func (h *Handler) OnAudio(timestamp uint32, payload io.Reader, streamID uint32) 
 		return err
 	}
 
-	eventID := strconv.FormatUint(uint64(streamID), 10) 
+	eventID := strconv.FormatUint(uint64(streamID), 10)
 	pubsub, _ := h.relayService.GetPubsub(eventID)
 
 	_ = pubsub.GetPub().Publish(&flvtag.FlvTag{

--- a/handler.go
+++ b/handler.go
@@ -66,8 +66,6 @@ func (h *Handler) OnPublish(_ *rtmp.StreamContext, timestamp uint32, cmd *rtmpms
 		return errors.New("PublishingName is empty")
 	}
 
-	log.Println(cmd.PublishingName)
-
 	var pubsub *Pubsub
 	var err error
 	pubsub, err = h.relayService.GetPubsub(cmd.PublishingName)
@@ -158,7 +156,7 @@ func (h *Handler) OnVideo(timestamp uint32, payload io.Reader, streamID uint32) 
 
 	video.Data = data
 
-	eventID := strconv.FormatUint(uint64(streamID), 10) 
+	eventID := strconv.FormatUint(uint64(streamID), 10)
 	pubsub, _ := h.relayService.GetPubsub(eventID)
 
 	_ = pubsub.GetPub().Publish(&flvtag.FlvTag{

--- a/pubsub.go
+++ b/pubsub.go
@@ -42,6 +42,10 @@ func (pb *Pubsub) GetPub() *Pub {
 	return pb.pub
 }
 
+func (pb *Pubsub) GetSubsLength() int {
+	return len(pb.subs)
+}
+
 func (pb *Pubsub) Pub() *Pub {
 
 	pub := &Pub{
@@ -87,7 +91,10 @@ func (p *Pub) Publish(flv *flvtag.FlvTag, content []byte) error {
 
 
 		case *flvtag.VideoData:
+			log.Println("VIdeo data")
+			i := 0
 			for _, sub := range p.pb.subs {
+				log.Println(i)
 				data := content
 
 				_ = sub.onEvent(flv, data)

--- a/pubsub.go
+++ b/pubsub.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"sync"
 	"log"
 
@@ -141,29 +140,3 @@ func (s *Sub) Close() error {
 	return nil
 }
 
-func cloneView(flv *flvtag.FlvTag) *flvtag.FlvTag {
-
-	v := *flv
-
-	switch flv.Data.(type) {
-		case *flvtag.AudioData:
-			dCloned := *v.Data.(*flvtag.AudioData)
-			v.Data = &dCloned
-
-			dCloned.Data = bytes.NewBuffer(dCloned.Data.(*bytes.Buffer).Bytes())
-
-		case *flvtag.VideoData:
-			dCloned := *v.Data.(*flvtag.VideoData)
-			v.Data = &dCloned
-
-			dCloned.Data = bytes.NewBuffer(dCloned.Data.(*bytes.Buffer).Bytes())
-		
-		case *flvtag.ScriptData:
-			dCloned := *v.Data.(*flvtag.ScriptData)
-			v.Data = &dCloned
-
-		default:
-			panic("unreachable")
-	}
-	return &v
-}

--- a/pubsub.go
+++ b/pubsub.go
@@ -66,7 +66,6 @@ func (pb *Pubsub) Sub(audioTrack, videoTrack *webrtc.Track) *Sub {
 	}
 
 	pb.subs = append(pb.subs, sub)
-	log.Println("NEW SUB END")
 
 	return sub
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -91,10 +91,7 @@ func (p *Pub) Publish(flv *flvtag.FlvTag, content []byte) error {
 
 
 		case *flvtag.VideoData:
-			log.Println("VIdeo data")
-			i := 0
 			for _, sub := range p.pb.subs {
-				log.Println(i)
 				data := content
 
 				_ = sub.onEvent(flv, data)

--- a/pubsub.go
+++ b/pubsub.go
@@ -42,10 +42,6 @@ func (pb *Pubsub) GetPub() *Pub {
 	return pb.pub
 }
 
-func (pb *Pubsub) GetSubsLength() int {
-	return len(pb.subs)
-}
-
 func (pb *Pubsub) Pub() *Pub {
 
 	pub := &Pub{


### PR DESCRIPTION
- Websites can now request to watch the event before it starts and start receiving the video once the stream begins
- No need to refresh the page anymore